### PR TITLE
Bypass container layer for cluster data directories

### DIFF
--- a/common.bash
+++ b/common.bash
@@ -194,7 +194,7 @@ cleanup() {
 	workspace=$(workspace)
 
 	docker cp "${container_id}":/build/gpdb/src/test/regress/regression.diffs "${workspace}"/"${repo}"/src/test/regress || :
-	docker rm --force "${container_id}"
+	docker rm --force --volumes "${container_id}"
 }
 
 run() {

--- a/streamline-43/uber.bash
+++ b/streamline-43/uber.bash
@@ -48,6 +48,7 @@ create_container() {
 	docker run --detach -ti \
 		--init \
 		--cap-add SYS_PTRACE \
+		--volume /build \
 		--volume gpdbccache:/ccache \
 		--volume gpdb4releng:/opt/releng \
 		--volume orca:/orca:ro \

--- a/streamline-gpdb_master/uber.bash
+++ b/streamline-gpdb_master/uber.bash
@@ -53,6 +53,7 @@ create_container() {
 	workspace=$(workspace)
 	docker run --detach -ti \
 		--cap-add SYS_PTRACE \
+		--volume /build \
 		--volume gpdbccache:/ccache \
 		--volume gpdb4releng:/opt/releng \
 		--volume orca:/orca:ro \

--- a/streamline-master/uber.bash
+++ b/streamline-master/uber.bash
@@ -45,6 +45,7 @@ create_container() {
 	docker run --detach -ti \
 		--init \
 		--cap-add SYS_PTRACE \
+		--volume /build \
 		--volume gpdbccache:/ccache \
 		--volume orca:/orca:ro \
 		--volume "${workspace}":/workspace:ro \


### PR DESCRIPTION
AUFS and overlay2 directories are slow to traverse. I'm not suggesting we should not do away with the questionable way we drop AO tables, but using the host FS like ext4 and xfs buys us a lot of speed in the near term.
This reduces 25% of ICG time for ORCA, and ~40% of ICG time for planner:

optimizer|before/after this patch|time
---|---|---
off|before|27m6.137s
off|after|16m9.845s
on|before|31m12.139s
on|after|23m15.333s