### PR TITLE
Add flag --interactive-after-icg

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ This repository is a simple on-ramp to help contributors run tests (`installchec
    It will stop after starting the cluster, and you can follow the prompt to set
    any GUC before running `make installcheck`
 
+1. ICG failed, but uber script deletes the container! How do I look at the diff
+   against expected output?
+
+   `regression.diffs` is always copied out when tests fail, try to get the most out of that.
+
+1. uber script deletes the container when my tests fail! How do I attach to shit and debug?
+
+   If you need to debug after the tests fail (so you know which regress test to
+   re-run), run with the `--interactive-after-icg` flag
+   ```
+   streamline-43/uber.bash --interactive-after-icg
+   ```
+   It will run ICG, then stop in an interactive Bash prompt.
+
 1. Shit's *SLOW*
 
    If you are using Docker for Mac, [don't](VMware_Fusion.md).

--- a/common.bash
+++ b/common.bash
@@ -14,6 +14,9 @@ parse_opts() {
 			--interactive)
 				run_mode=interactive
 				;;
+			--interactive-after-icg)
+				run_mode=interactive_after_icg
+				;;
 			--use-stale-orca)
 				stale_orca=true
 				;;
@@ -214,6 +217,16 @@ run() {
 			;;
 		icg)
 			icg "${container_id}" "${relpath}" "${installcheck_mode}"
+			;;
+		interactive_after_icg)
+			if icg "${container_id}" "${relpath}" "${installcheck_mode}"; then
+				echo "ICG passed."
+				true
+			else
+				echo "ICG failed: returned status $?"
+			fi
+			docker exec -ti "${container_id}" /workspace/"${relpath}"/db_shell.bash
+			return 0
 			;;
 		*)
 			return 1


### PR DESCRIPTION
This is a much requested mode that combines the "ICG mode" and the
"interactive mode". To use it, substitute `--interactive-after-icg` for
`--interactive`.

Resolves #35