### PR TITLE
build unit tests before running them

### DIFF
--- a/streamline-master/build_gpdb.bash
+++ b/streamline-master/build_gpdb.bash
@@ -44,7 +44,14 @@ parse_args() {
 	done
 }
 
+build_unittest() {
+	git grep -lF mock.mk | \
+		xargs dirname | \
+		xargs -n1 make -s -j8 -C
+}
+
 unittest() {
+	build_unittest
 	make -s -j8 -C /build/gpdb/src/backend unittest-check
 }
 


### PR DESCRIPTION
This removes an oft-hit flakiness where our attempt to run unit tests in
parallel would nearly 100% fail something. Part of the problem is each
suite of tests depend on some of the common mocks, and there's no
coordination among the makes of different subdirs ...

Introduced in #32 (commit 4538197)
Fixes #48